### PR TITLE
Add Implementations section (servers / clients)

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,6 +379,81 @@
       </div>
     </div>
 
+    <!-- Implementations Section -->
+    <div class="bg-white rounded-xl p-5 md:p-8 mb-6 md:mb-8 shadow-md">
+      <h2
+        class="text-xl md:text-2xl text-primary border-b-2 border-secondary pb-2 mb-4 md:mb-6"
+      >
+        Implementations
+      </h2>
+      <p class="mb-6">
+        A living list of software implementing or building on Linked Web
+        Storage, grouped by role. LWS has a producer side (servers that serve
+        pods) and a consumer side (clients and apps that read from and write to
+        pods). Both are implementations.
+      </p>
+
+      <!-- Servers -->
+      <div class="bg-secondary/10 rounded-lg p-4 mb-6 border-l-4 border-secondary">
+        <h3 class="text-lg font-semibold text-primary mb-3">
+          Servers (produce LWS storage)
+        </h3>
+        <ul class="space-y-3">
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
+              href="https://github.com/JavaScriptSolidServer/JavaScriptSolidServer"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              JavaScript Solid Server (JSS)
+            </a>
+            — serves LWS pods with W3C Controlled Identifier (CID v1.0) profiles,
+            the LWS Authentication Suite, did:nostr, NIP-98, and WebSocket/SSE
+            notifications. One-command install:
+            <code class="bg-white px-1 rounded text-sm">npx jspod</code>.
+          </li>
+        </ul>
+      </div>
+
+      <!-- Clients & Apps -->
+      <div class="bg-secondary/10 rounded-lg p-4 mb-6 border-l-4 border-secondary">
+        <h3 class="text-lg font-semibold text-primary mb-3">
+          Clients &amp; Apps (consume LWS storage)
+        </h3>
+        <ul class="space-y-3">
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
+              href="https://github.com/chapeaux/porter"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              Porter
+            </a>
+            — pure-Deno multi-agent orchestration platform. Stores agent teams,
+            models, MCP servers, and credentials in LWS pods via SSO and
+            server-side token exchange, so configuration persists across
+            deployments.
+          </li>
+        </ul>
+      </div>
+
+      <div class="mt-4 p-3 bg-secondary/10 rounded-lg text-sm">
+        <strong class="text-primary">Adding an implementation:</strong> open a
+        pull request against
+        <a
+          href="https://github.com/linkedwebstorage/linkedwebstorage.com"
+          target="_blank"
+          class="text-accent hover:text-primary transition-colors font-semibold"
+        >
+          linkedwebstorage.com
+        </a>
+        with your implementation, its role (server / client / library), and the
+        LWS surface it implements.
+      </div>
+    </div>
+
     <!-- FAQ Section -->
     <div class="bg-white rounded-xl p-5 md:p-8 mb-6 md:mb-8 shadow-md">
       <h2


### PR DESCRIPTION
Adds a role-categorized Implementations section: Servers (JSS) and Clients & Apps (Porter), plus a how-to-add-an-implementation PR pointer. Role-categorization (producer vs consumer) keeps entries precise as the list grows.