### PR TITLE
Add Auth Suite FPWD and CID 1.0 to Official W3C Documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,6 +584,29 @@
           <li class="relative pl-5">
             <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
             <a
+              href="https://www.w3.org/TR/2026/WD-lws10-authn-ssi-cid-20260423/"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              LWS 1.0 Authentication Suite (First Public Working Draft)
+            </a>
+            - Authentication using Controlled Identifiers and Self-Sovereign
+            Identity, published 2026-04-23
+          </li>
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
+              href="https://www.w3.org/TR/cid-1.0/"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              Controlled Identifiers (CID) 1.0
+            </a>
+            - W3C Recommendation underpinning LWS authentication
+          </li>
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
               href="https://www.w3.org/TR/lws-ucs/"
               target="_blank"
               class="text-accent hover:text-primary transition-colors font-semibold"


### PR DESCRIPTION
Completes the official-documents list with the two missing W3C references: LWS 1.0 Authentication Suite (FPWD, 2026-04-23) and Controlled Identifiers (CID) 1.0. Both sit alongside the existing Protocol ED / Use Cases / Charter links.