### PR TITLE
Add lws-keycloak + carbon-cid and LWS spec-module links

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,38 @@
         </ul>
       </div>
 
+      <!-- Libraries & Auth -->
+      <div class="bg-secondary/10 rounded-lg p-4 mb-6 border-l-4 border-secondary">
+        <h3 class="text-lg font-semibold text-primary mb-3">
+          Libraries &amp; Authentication
+        </h3>
+        <ul class="space-y-3">
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
+              href="https://github.com/jeswr/lws-keycloak"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              lws-keycloak
+            </a>
+            — a Keycloak-based prototype of LWS authentication and authorization.
+          </li>
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <a
+              href="https://github.com/filip26/carbon-cid"
+              target="_blank"
+              class="text-accent hover:text-primary transition-colors font-semibold"
+            >
+              carbon-cid
+            </a>
+            — a Java implementation of W3C Controlled Identifiers (CID), the
+            standard underpinning LWS authentication.
+          </li>
+        </ul>
+      </div>
+
       <div class="mt-4 p-3 bg-secondary/10 rounded-lg text-sm">
         <strong class="text-primary">Adding an implementation:</strong> open a
         pull request against
@@ -580,6 +612,18 @@
               LWS Protocol 1.0 Specification (Editor's Draft)
             </a>
             - Core protocol for resource access, authentication, and operations
+          </li>
+          <li class="relative pl-5">
+            <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>
+            <span class="font-semibold text-primary">Specification modules (Editor's Drafts)</span>
+            -
+            <a href="https://w3c.github.io/lws-protocol/lws10-core/" target="_blank" class="text-accent hover:text-primary transition-colors">Core</a>,
+            <a href="https://w3c.github.io/lws-protocol/lws10-vocab/" target="_blank" class="text-accent hover:text-primary transition-colors">Vocabulary</a>,
+            and authentication suites:
+            <a href="https://w3c.github.io/lws-protocol/lws10-authn-openid/" target="_blank" class="text-accent hover:text-primary transition-colors">OpenID</a>,
+            <a href="https://w3c.github.io/lws-protocol/lws10-authn-saml/" target="_blank" class="text-accent hover:text-primary transition-colors">SAML</a>,
+            <a href="https://w3c.github.io/lws-protocol/lws10-authn-ssi-cid/" target="_blank" class="text-accent hover:text-primary transition-colors">SSI (CID)</a>,
+            <a href="https://w3c.github.io/lws-protocol/lws10-authn-ssi-did-key/" target="_blank" class="text-accent hover:text-primary transition-colors">SSI (did:key)</a>
           </li>
           <li class="relative pl-5">
             <span class="absolute left-0 top-0.5 text-accent font-bold">•</span>


### PR DESCRIPTION
Two additions, kept compact: (1) a 'Libraries & Authentication' group with lws-keycloak (Jesse Wright's Keycloak-based LWS auth prototype) and carbon-cid (Filip Kolárik's Java CID implementation); (2) a single compact entry linking the six LWS 1.0 Editor's Draft modules (core, vocab, and the OpenID / SAML / SSI-CID / SSI-did:key auth suites). No new sections beyond the one implementation group.