### PR TITLE
Link meeting calendar, minutes, and mailing list in contribute FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,11 +559,21 @@
               href="https://github.com/w3c/lws-protocol"
               class="text-accent hover:text-primary"
               >GitHub repositories</a
-            >, participate in
+            >, check the
             <a
-              href="https://www.w3.org/groups/wg/lws/"
+              href="https://www.w3.org/groups/wg/lws/calendar/"
               class="text-accent hover:text-primary"
-              >Working Group meetings</a
+              >meeting calendar</a
+            >, read the public
+            <a
+              href="https://www.w3.org/2026/05/11-lws-minutes.html"
+              class="text-accent hover:text-primary"
+              >meeting minutes</a
+            >, follow the
+            <a
+              href="https://lists.w3.org/Archives/Public/public-lws-wg/"
+              class="text-accent hover:text-primary"
+              >mailing list</a
             >, or submit use cases to the
             <a
               href="https://github.com/w3c/lws-ucs"


### PR DESCRIPTION
The 'How can I contribute?' FAQ answer linked only the WG landing page. This adds, inside the existing answer (no new sections): the W3C meeting calendar, the public meeting minutes (latest published, 11 May 2026 — there is no minutes index, so this is the most recent dated page), and the public mailing list. All are surfaces the official WG page publishes.